### PR TITLE
Add resolution configuration to resolve format selection errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,7 @@ viam-env/
 # Unit tests / Coverage reports
 .cache
 .DS_Store
+
+*.spec
+build/
+dist/

--- a/README.md
+++ b/README.md
@@ -47,19 +47,14 @@ The following attributes are available for `julie:livestream:youtube-stream` cam
 | Name | Type | Inclusion | Description |
 | ---- | ---- | --------- | ----------- |
 | `video_url` | string | **Required** |  This URL specifies the livestream video that the camera will play. |
+| `resolution` | string | Optional |  The resolution specifier for the video, i.e. "480p", "720p", "1080p", "1440p", "bestvideo" (default) |
 
 ### Example Configuration
 
 ```json
 {
-      "name": "my-youtube-stream",
-      "namespace": "rdk",
-      "type": "camera",
-      "model": "julie:livestream:youtube-stream",
-      "attributes": {
-        "video_url": "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
-      }
-    }
+    "video_url": "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+}
 ```
 
 ## Troubleshooting

--- a/meta.json
+++ b/meta.json
@@ -7,7 +7,9 @@
   "models": [
     {
       "api": "rdk:component:camera",
-      "model": "julie:livestream:youtube-stream"
+      "model": "julie:livestream:youtube-stream",
+      "short_description": "Display YouTube videos as a live stream from a camera.",
+      "markdown_link": "README.md#configure-your-camera"
     }
   ],
   "build": {

--- a/src/youtubeStream.py
+++ b/src/youtubeStream.py
@@ -1,14 +1,13 @@
 import asyncio
 import cv2
-import time
 
-from typing import ClassVar, Dict, Mapping, Optional, Any, Tuple, List
+from typing import ClassVar, Dict, Mapping, Optional, Any, Set, Tuple, List
 from typing_extensions import Self
 from yt_dlp import YoutubeDL
 
 from viam.components.camera import Camera
 from viam.logging import getLogger
-from viam.media.video import ViamImage, Optional, CameraMimeType, NamedImage
+from viam.media.video import ViamImage, CameraMimeType, NamedImage
 from viam.module.types import Reconfigurable
 from viam.proto.app.robot import ComponentConfig
 from viam.proto.common import ResponseMetadata
@@ -18,43 +17,53 @@ from viam.utils import struct_to_dict
 
 LOGGER = getLogger(__name__)
 
+
 class youtubeStream(Camera, Reconfigurable):
-    
     """
     Camera represents any physical hardware that can capture frames.
     """
+
     video_url: str
     default_url: str = "https://www.youtube.com/watch?v=MusSS4R9SPw"
+    resolution: str = "bestvideo"
 
     MODEL: ClassVar[Model] = Model(ModelFamily("julie", "livestream"), "youtube-stream")
     REQUIRED_ATTRIBUTES: ClassVar[List[str]] = ["video_url"]
-    
 
     # Constructor
     @classmethod
-    def new(cls, config: ComponentConfig, dependencies: Mapping[ResourceName, ResourceBase]) -> Self:
+    def new(
+        cls, config: ComponentConfig, dependencies: Mapping[ResourceName, ResourceBase]
+    ) -> Self:
         my_stream = cls(config.name)
         my_stream.reconfigure(config, dependencies)
         return my_stream
-    
+
     def __init__(self, name: str):
         super().__init__(name)
-        self.video_cap: Optional [cv2.VideoCapture] = None
+        self.video_cap: Optional[cv2.VideoCapture] = None
 
     # Validates JSON Configuration
     @classmethod
     def validate(cls, config: ComponentConfig):
         # Here we validate config, the following is just an example and should be updated as needed
-        is_missing_attrs = [attr for attr in cls.REQUIRED_ATTRIBUTES if attr not in config.attributes]
+        is_missing_attrs = [
+            attr for attr in cls.REQUIRED_ATTRIBUTES if attr not in config.attributes
+        ]
         if is_missing_attrs:
             LOGGER.error("Missing required attributes in Youtube stream Configuration.")
-            raise ValueError(f"Missing required attributes in Youtube stream Configuration: {', '.join(is_missing_attrs)}")
+            raise ValueError(
+                f"Missing required attributes in Youtube stream Configuration: {', '.join(is_missing_attrs)}"
+            )
         return
-    
-    def reconfigure(self, config: ComponentConfig, dependencies: Mapping[ResourceName, ResourceBase]):
-        LOGGER.info("Reconfiguring " + self.name)
+
+    def reconfigure(
+        self, config: ComponentConfig, dependencies: Mapping[ResourceName, ResourceBase]
+    ):
+        LOGGER.debug("Reconfiguring " + self.name)
         attrs = struct_to_dict(config.attributes)
         self.video_url = str(attrs.get("video_url", self.default_url))
+        self.resolution = str(attrs.get("resolution", self.resolution))
 
         self.config = config
         self.dependencies = dependencies
@@ -68,26 +77,60 @@ class youtubeStream(Camera, Reconfigurable):
 
         # Init. the video capture object with the fetched stream URL
         self.video_cap = cv2.VideoCapture(stream_url)
-    
+
     def get_video_url(self, youtube_url: str) -> str:
         # Fetch the direct video URL from YouTube using yt_dlp.
         ydl_opts = {
-            'format': 'best',
-            'quiet': True,
-            'no_warnings': True,
-            'noplaylist': True,
+            "quiet": True,
+            "no_warnings": True,
+            "noplaylist": True,
         }
+        # allow for special format names, see https://github.com/yt-dlp/yt-dlp?tab=readme-ov-file#format-selection
+        if not self.resolution.endswith("p"):
+            ydl_opts["format"] = self.resolution
+
         ydl = YoutubeDL(ydl_opts)
         try:
             info = ydl.extract_info(youtube_url, download=False)
-            stream_url = info['url']
-            LOGGER.info(f"Fetched video stream URL: {stream_url}")
+            if info.get("url"):
+                stream_url = info["url"]
+            elif formats := info.get("formats"):
+                formats_at_resolution = [
+                    format
+                    for format in formats
+                    if self.resolution in format.get("format_note", "")
+                    and format.get("ext", "") in ["webm", "mp4"]
+                ]
+                if len(formats_at_resolution) > 0 and (
+                    available_format := formats_at_resolution[0]
+                ):
+                    stream_url = available_format["url"]
+                else:
+                    format_list = set([
+                        f["format_note"]
+                        for f in formats
+                        if f.get("format_note", "").endswith("p")
+                        and f.get("ext", "") in ["webm", "mp4"]
+                    ])
+                    raise RuntimeError(
+                        f"Unable to select video with resolution '{self.resolution}'. Please select from that available formats: {format_list}"
+                    )
+            else:
+                raise RuntimeError("No possible formats available for video stream.")
+            LOGGER.debug(f"Fetched video stream URL: {stream_url}")
             return stream_url
         except Exception as e:
             LOGGER.error(f"Error fetching video stream URL: {e}")
             raise RuntimeError("Failed to fetch the YouTube stream URL.")
-        
-    async def get_image(self, mime_type: str = "", *, extra: Optional[Dict[str, Any]] = None, timeout: Optional[float] = None, **kwargs) -> ViamImage:
+
+    async def get_image(
+        self,
+        mime_type: str = "",
+        *,
+        extra: Optional[Dict[str, Any]] = None,
+        timeout: Optional[float] = None,
+        **kwargs,
+    ) -> ViamImage:
         # Check if video capture is initialized
         if self.video_cap is None:
             raise RuntimeError("Video capture is not initialized.")
@@ -96,26 +139,32 @@ class youtubeStream(Camera, Reconfigurable):
             ret, frame = self.video_cap.read()
             if ret:
                 break
-            await asyncio.sleep(1)  # Wait 1 second before retrying 
+            await asyncio.sleep(1)  # Wait 1 second before retrying
         if not ret:
             raise RuntimeError("Failed to capture any frame from the video.")
-                
-        ret, jpeg = cv2.imencode('.jpg', frame)
+
+        ret, jpeg = cv2.imencode(".jpg", frame)
         if not ret:
             raise RuntimeError("Failed to encode frame as JPEG.")
-        
+
         image_data = jpeg.tobytes()
         return ViamImage(image_data, CameraMimeType.JPEG)
-    
-    async def get_images(self, *, timeout: Optional[float] = None, **kwargs) -> Tuple[List[NamedImage], ResponseMetadata]:
+
+    async def get_images(
+        self, *, timeout: Optional[float] = None, **kwargs
+    ) -> Tuple[List[NamedImage], ResponseMetadata]:
         raise NotImplementedError()
 
     async def get_point_cloud(
-        self, *, extra: Optional[Dict[str, Any]] = None, timeout: Optional[float] = None, **kwargs
+        self,
+        *,
+        extra: Optional[Dict[str, Any]] = None,
+        timeout: Optional[float] = None,
+        **kwargs,
     ) -> Tuple[bytes, str]:
         raise NotImplementedError()
-        
-    async def get_properties(self, *, timeout: Optional[float] = None, **kwargs) -> 'Camera.Properties':
-        return Camera.Properties(
-        mime_types=['image/jpeg']  
-    )
+
+    async def get_properties(
+        self, *, timeout: Optional[float] = None, **kwargs
+    ) -> "Camera.Properties":
+        return Camera.Properties(mime_types=["image/jpeg"])


### PR DESCRIPTION
Reported in the Viam Discord: https://discord.com/channels/1083489952408539288/1358874718983291023

Not all video streams from YouTube can be resolved with the default "best" format set by this module. This PR provides the option to select a specific resolution, similar to YouTube's own interface for videos. It also updates the default format to "bestvideo" as a safer selection based on the details from [yt-dlp](https://github.com/yt-dlp/yt-dlp?tab=readme-ov-file#format-selection) since this module shouldn't care about formats with audio as a camera component. 

The module metadata will need to be updated using `viam module update` after this is merged to make sure the new inline docs are supported. 